### PR TITLE
Fix imports for case-sensitive file systems

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -4,7 +4,7 @@
 const _            = require("lodash");
 const path         = require("path");
 
-const CompilerImpl  = require("../src/compiler");
+const CompilerImpl  = require("../src/Compiler");
 const OJSymbolTyper = require("../src/model/OJSymbolTyper");
 
 

--- a/src/model/OJClass.js
+++ b/src/model/OJClass.js
@@ -8,9 +8,9 @@
 "use strict";
 
 const _           = require("lodash");
-const OJError     = require("../errors").OJError;
-const OJWarning   = require("../errors").OJWarning;
-const Utils       = require("../utils");
+const OJError     = require("../Errors").OJError;
+const OJWarning   = require("../Errors").OJWarning;
+const Utils       = require("../Utils");
 const OJIvar      = require("./OJIvar");
 const OJProperty  = require("./OJProperty");
 const OJMethod    = require("./OJMethod");

--- a/src/model/OJCompileCallbackFile.js
+++ b/src/model/OJCompileCallbackFile.js
@@ -7,8 +7,8 @@
 
 "use strict";
 
-const Utils     = require("../utils");
-const OJWarning = require("../errors").OJWarning;
+const Utils     = require("../Utils");
+const OJWarning = require("../Errors").OJWarning;
 
 
 module.exports = class OJCompileCallbackFile {

--- a/src/model/OJModel.js
+++ b/src/model/OJModel.js
@@ -7,8 +7,8 @@
 "use strict";
 
 const _             = require("lodash");
-const OJError       = require("../errors").OJError;
-const Utils         = require("../utils");
+const OJError       = require("../Errors").OJError;
+const Utils         = require("../Utils");
 const OJClass       = require("./OJClass");
 const OJGlobal      = require("./OJGlobal");
 const OJProtocol    = require("./OJProtocol");

--- a/src/model/OJProtocol.js
+++ b/src/model/OJProtocol.js
@@ -8,8 +8,8 @@
 "use strict";
 
 const _          = require("lodash");
-const OJError    = require("../errors").OJError;
-const Utils      = require("../utils");
+const OJError    = require("../Errors").OJError;
+const Utils      = require("../Utils");
 const OJProperty = require("./OJProperty");
 const OJMethod   = require("./OJMethod");
 

--- a/src/model/OJSymbolTyper.js
+++ b/src/model/OJSymbolTyper.js
@@ -9,8 +9,8 @@
 "use strict";
 
 const _           = require("lodash");
-const OJError     = require("../errors").OJError;
-const Utils       = require("../utils");
+const OJError     = require("../Errors").OJError;
+const Utils       = require("../Utils");
 const OJClass     = require("./OJClass");
 const OJProtocol  = require("./OJProtocol");
 const OJMethod    = require("./OJMethod");

--- a/src/model/OJType.js
+++ b/src/model/OJType.js
@@ -7,8 +7,8 @@
 
 "use strict";
 
-const OJError     = require("../errors").OJError;
-const Utils       = require("../utils");
+const OJError     = require("../Errors").OJError;
+const Utils       = require("../Utils");
 const _           = require("lodash");
 
 

--- a/src/typechecker/DiagnosticParser.js
+++ b/src/typechecker/DiagnosticParser.js
@@ -9,7 +9,7 @@
 
 const _         = require("lodash");
 const ts        = require("typescript");
-const OJWarning = require("../errors").OJWarning;
+const OJWarning = require("../Errors").OJWarning;
 
 const sBlacklistCodes  = [ 2417 ];
 

--- a/src/typechecker/Typechecker.js
+++ b/src/typechecker/Typechecker.js
@@ -16,7 +16,7 @@ const ts      = require("typescript");
 
 const DefinitionMaker  = require("./DefinitionMaker");
 const DiagnosticParser = require("./DiagnosticParser");
-const Utils            = require("../utils")
+const Utils            = require("../Utils")
 
 
 module.exports = class Typechecker {

--- a/test/tests.js
+++ b/test/tests.js
@@ -8,8 +8,8 @@ const cp     = require("child_process");
 const fs     = require("fs");
 const path   = require("path");
 
-const OJError   = require("../src/errors.js").OJError;
-const OJWarning = require("../src/errors.js").OJWarning;
+const OJError   = require("../src/Errors.js").OJError;
+const OJWarning = require("../src/Errors.js").OJWarning;
 const ojc       = require("../lib/api");
 const oj        = require("../lib/runtime");
 


### PR DESCRIPTION
This makes it possible to use OJ in GNU/Linux systems, and probably
others as well where file systems a strictly case-sensitive (and not
just case-preserving as MacOS' HFS+).